### PR TITLE
Add simple result view with Deepen Insight link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # InnerMap
+
+This repository provides a minimal example of the InnerMap result screen. Open `results.html` in a browser to view the demo interface with a prominent **Deepen Insight** option, navigation to PDF guides and daily practices, and a summary of next steps.

--- a/daily-practices.html
+++ b/daily-practices.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Daily Practices</title>
+</head>
+<body>
+    <h1>Daily Practices</h1>
+    <p>Incorporate these practices into your routine:</p>
+    <ul>
+        <li>Practice 1</li>
+        <li>Practice 2</li>
+    </ul>
+    <a href="results.html">Back to Results</a>
+</body>
+</html>

--- a/deepen_insight.html
+++ b/deepen_insight.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Deepen Insight</title>
+</head>
+<body>
+    <h1>Deepen Your Insight</h1>
+    <p>Here you can explore additional resources to better understand your results.</p>
+    <ul>
+        <li><a href="pdf-guides.html">Go to PDF Guides</a></li>
+        <li><a href="daily-practices.html">View Daily Practices</a></li>
+    </ul>
+    <a href="results.html">Back to Results</a>
+</body>
+</html>

--- a/pdf-guides.html
+++ b/pdf-guides.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>PDF Guides</title>
+</head>
+<body>
+    <h1>PDF Guides</h1>
+    <p>This page lists PDF resources for further reading.</p>
+    <ul>
+        <li><a href="#">Guide 1 (PDF)</a></li>
+        <li><a href="#">Guide 2 (PDF)</a></li>
+    </ul>
+    <a href="results.html">Back to Results</a>
+</body>
+</html>

--- a/results.html
+++ b/results.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>InnerMap Results</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+        }
+        .deepen-insight {
+            display: block;
+            background-color: #4CAF50;
+            color: white;
+            padding: 20px;
+            text-align: center;
+            font-size: 1.5em;
+            text-decoration: none;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+        .navigation {
+            margin-top: 20px;
+        }
+        .navigation a {
+            margin-right: 15px;
+        }
+        .next-steps {
+            margin-top: 30px;
+            background: #f2f2f2;
+            padding: 15px;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Your Results</h1>
+    <p>Thank you for completing the assessment. Use the options below to deepen your insight and continue your journey.</p>
+
+    <a href="deepen_insight.html" class="deepen-insight">Deepen Insight</a>
+
+    <div class="navigation">
+        <strong>Resources:</strong>
+        <a href="pdf-guides.html">PDF Guides</a>
+        <a href="daily-practices.html">Daily Practices</a>
+    </div>
+
+    <div class="next-steps">
+        <h2>Next Steps</h2>
+        <p>
+            1. Explore the PDF guides for a detailed explanation of your results.<br>
+            2. Start a daily practice to integrate these insights into your routine.<br>
+            3. Return regularly to track your progress and continue deepening your understanding.
+        </p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a minimal demo of the result screen
- add prominent **Deepen Insight** button
- link to PDF guides and daily practices
- summarize next steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f7bc7324832c9baeb3a409fa7115